### PR TITLE
Update tryton.cfg

### DIFF
--- a/tryton.cfg
+++ b/tryton.cfg
@@ -2,3 +2,6 @@
 version=3.2.0.1
 depends:
     ir
+website='https://github.com/openlabs/trytond-attachment-s3'
+description='Amazon S3 backend for Tryton Attachments'
+


### PR DESCRIPTION
`url` and `description` not showing up for package metadata
