### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ trytond-attachment-s3
 Amazon S3 backend for Tryton Attachments
 
 [![Build Status](https://travis-ci.org/openlabs/trytond-attachment-s3.svg?branch=develop)](https://travis-ci.org/openlabs/trytond-attachment-s3)
-[![Downloads](https://pypip.in/download/trytond_attachment_s3/badge.svg)](https://pypi.python.org/pypi/trytond_attachment_s3/)
-[![Latest Version](https://pypip.in/version/trytond_attachment_s3/badge.svg)](https://pypi.python.org/pypi/trytond_attachment_s3/)
-[![Development Status](https://pypip.in/status/trytond_attachment_s3/badge.svg)](https://pypi.python.org/pypi/trytond_attachment_s3/)
+[![Downloads](https://img.shields.io/pypi/dm/trytond_attachment_s3.svg)](https://pypi.python.org/pypi/trytond_attachment_s3/)
+[![Latest Version](https://img.shields.io/pypi/v/trytond_attachment_s3.svg)](https://pypi.python.org/pypi/trytond_attachment_s3/)
+[![Development Status](https://img.shields.io/pypi/status/trytond_attachment_s3.svg)](https://pypi.python.org/pypi/trytond_attachment_s3/)


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20trytond-attachment-s3))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `trytond-attachment-s3`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.